### PR TITLE
Changed algolia settings for search

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -55,4 +55,5 @@
 <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "feed.xml" | prepend: site.url }}">
 
 <!-- Algolia DocSearch -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
+<link rel="stylesheet" href="{{ "/css/algolia-customization.css" | prepend: site.baseurl}}">

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -73,7 +73,7 @@
                 <li>
                     <!--start search-->
                     <div id="search-demo-container">
-                      <input type="text" id="search-input" placeholder="{{site.data.strings.search_placeholder_text}}">
+                      <div id="search-input" placeholder="{{site.data.strings.search_placeholder_text}}"></div>
                       <ul id="results-container"></ul>
                     </div>
                     <!--end search-->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -131,12 +131,15 @@
     </div>
 
     <!-- Algolia DocSearch -->
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
     <script type="text/javascript"> docsearch({
-            apiKey: '1a6f8a40b360b474e07ba965ab9e7b34',
+            appId: '6B8NQD4J1U',
+            apiKey: '390b847470dac15dbc26699d58ee9d56',
             indexName: 'flexberry',
-            inputSelector: '#search-input',
-            algoliaOptions: { 'facetFilters': ["lang: {{ page.lang }}"] },
+            container: '#search-input',
+            searchParameters: {
+                facetFilters: ["lang: {{ page.lang }}"] 
+            },
             debug: false // Set debug to true if you want to inspect the dropdown
         });
     </script>

--- a/css/algolia-customization.css
+++ b/css/algolia-customization.css
@@ -1,0 +1,3 @@
+.DocSearch-Modal {
+  margin: 200px auto auto;
+}


### PR DESCRIPTION
Изменены настройки алгории для поиска. В самой алголии был переход с версии DocSearch 2 на 3. Кроме того, ранее все настройки сайтов были на https://dashboard.algolia.com/, то теперь Crawler (штука, которая непосредственно сайты парсит, а потом по этим данным алголия строит алгоритмы) находится на отдельном адресе https://crawler.algolia.com/ (при этом учётка одна и та же).

В данном ПР пробная смена настроек. Новые идентификаторы взяты из настроек индекса в https://dashboard.algolia.com/, те же указаны в автоматически появившемся конфиге на https://crawler.algolia.com/). Новые названия настроек в соответствии с https://docsearch.algolia.com/docs/migrating-from-v2/.

Как управлять Crawler, написано здесь: https://docsearch.algolia.com/docs/manage-your-crawls.